### PR TITLE
Fix compilation and dependency issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,13 @@
             <version>${logback.version}</version>
         </dependency>
 
+        <!-- Google Guava -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.1.3-jre</version>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/fuzzyga/core/FuzzySystemFitnessEvaluator.java
+++ b/src/main/java/com/fuzzyga/core/FuzzySystemFitnessEvaluator.java
@@ -61,7 +61,7 @@ public class FuzzySystemFitnessEvaluator implements FitnessEvaluator {
         return new Chromosome(genes);
     }
 
-    TskInferenceSystem decode(Chromosome chromosome) {
+    public TskInferenceSystem decode(Chromosome chromosome) {
         double[] genes = chromosome.genes();
         int geneIndex = 0;
 

--- a/src/main/java/com/fuzzyga/core/data/DataPoint.java
+++ b/src/main/java/com/fuzzyga/core/data/DataPoint.java
@@ -4,6 +4,7 @@ import com.fuzzyga.fuzzy.InputVariable;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**


### PR DESCRIPTION
This commit addresses several compilation errors:

- Adds the Google Guava dependency to `pom.xml` to resolve missing classes from `com.google.common.collect`.
- Adds the `java.util.HashMap` import to `DataPoint.java` to fix a "cannot find symbol" error.
- Changes the `decode` method in `FuzzySystemFitnessEvaluator.java` to be public, resolving an access error from the `App` class.

With these changes, the project now compiles and all tests pass.